### PR TITLE
Update Transaction.php

### DIFF
--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -132,13 +132,12 @@ class Transaction
             throw new \Exception("business_key is required", 1);
         }
 
-        $this->curl->get($this->base_url . "/checkout/" . $reference);
-
-        if ($this->curl->error) {
-
-            // throw error
-            throw new \Exception($this->curl->errorMessage, 1);
+        try {
+            $this->curl->get($this->base_url . "/checkout/" . $reference);
         }
+        catch (\Exception $e){
+            throw new \Exception($this->curl->errorMessage, 1);
+        } 
 
         return $this->curl->response;
     }

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -154,9 +154,10 @@ class Transaction
             throw new \Exception("business_key is required", 1);
         }
 
-        $this->curl->put($this->base_url . "/" . $reference);
-
-        if ($this->curl->error) {
+        try {
+            $this->curl->put($this->base_url . "/checkout/" . $reference);
+        }
+        catch (\Exception $e){
             // throw error
             throw new \Exception($this->curl->errorMessage, 1);
         }


### PR DESCRIPTION
Prior to this change, the fetch method generated an HTTP / 1.1 Error 422 Unprocessable Entity if the reference was invalid. Now it returns a message like this: stdClass Object ( [message] => The given data was invalid. [errors] => stdClass Object ( [token] => Array ( [0] => Invalid Transaction reference ) ) )